### PR TITLE
Update cmcBot.js

### DIFF
--- a/cmcBot.js
+++ b/cmcBot.js
@@ -168,7 +168,7 @@ async function checkForProfit(token) {
 			token.currentValue = currentValue;
 			const takeProfit = (parseFloat(ethers.utils.formatUnits(token.intitialValue)) * (token.profitPercent + token.tokenSellTax) / 100 + parseFloat(ethers.utils.formatUnits(token.intitialValue))).toFixed(8).toString();
 			const profitDesired = ethers.utils.parseUnits(takeProfit);
-			let targetValueToSetNewStopLoss = ethers.utils.parseUnits((parseFloat(ethers.utils.formatUnits(token.newValue)) * (token.trailingStopLossPercent / 100 + token.tokenSellTax / 100) + parseFloat(ethers.utils.formatUnits(token.newValue))).toFixed(8).toString());
+			let targetValueToSetNewStopLoss = ethers.utils.parseUnits((parseFloat(ethers.utils.formatUnits(token.newValue)) * (token.trailingStopLossPercent / 100) + parseFloat(ethers.utils.formatUnits(token.newValue))).toFixed(8).toString());
 			console.log("\u001b[38;5;81m" + "Target value for trailing StopLoss:", ethers.utils.formatUnits(targetValueToSetNewStopLoss), "\u001b[0m");
 			let stopLoss = token.stopLoss;
 


### PR DESCRIPTION
It is better to leave only trailingStopLossPercent here, since SellTax can be in the range from 0 to 30, that is, after the purchase, we can get a TSL step of 30 or 40% instead of 10%. This is already a loss of control over the settings